### PR TITLE
Fix model load

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,23 +41,22 @@
             return blob;
         };
         const contentType = "application/octet-stream";
-        const blob = b64toBlob(sceneModel, contentType);
-        const blobUrl = URL.createObjectURL(blob);
-		
 		function getModelURL(model) {return URL.createObjectURL(b64toBlob(model, contentType));}
-        var myviewer = null;
+        var blobUrl = getModelURL(sceneModel);
+		var myviewer = null;
+
         setTimeout(function() {
             myviewer = new marmoset.WebViewer(document.body.clientWidth, window.innerHeight-200, blobUrl);
             document.getElementById("view").appendChild(myviewer.domRoot);
             myviewer.loadScene();
         }, 300);
 
-		
         function changeView(model) {
-			myviewer.wake();
-			myviewer.resize(document.body.clientWidth, window.innerHeight-200);
-            myviewer.loadScene(getModelURL(model));
-			myviewer.reDrawScene();
+			document.querySelector('#view div').remove();
+			myviewer.unload();blobUrl = getModelURL(model);delete myviewer.canvas;myviewer=null;
+            myviewer = new marmoset.WebViewer(document.body.clientWidth, window.innerHeight-200, blobUrl);
+            document.getElementById("view").appendChild(myviewer.domRoot);
+            myviewer.loadScene();
         }
     </script>
 </head>


### PR DESCRIPTION
由于marmoset.JS的问题，直接loadscene()的方法会导致动画控制ui消失，并且无法初始化。
改用原来的办法来加载模型读取，改用delete myviewer.canvas来删除内容，经过试验，可以稳定内存开销。